### PR TITLE
Enable key shortcuts in menus

### DIFF
--- a/menu.rb
+++ b/menu.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'tty-prompt'
+require_relative 'tty_prompt_key_select_patch'
 require 'pastel'
 require_relative 'project_manager'
 require_relative 'stock_manager'

--- a/tty_prompt_key_select_patch.rb
+++ b/tty_prompt_key_select_patch.rb
@@ -1,0 +1,23 @@
+# Monkey patch to add one-key selection to TTY::Prompt's List menu
+# This patch allows using the `key:` option with `prompt.select` choices.
+
+require 'tty/prompt'
+
+module TTY
+  class Prompt
+    class List
+      alias_method :orig_keypress, :keypress
+
+      def keypress(event)
+        if !filterable? && (choice = choices.find_by(:key, event.value))
+          unless choice.disabled?
+            @active = choices.index(choice) + 1
+            @done = true
+          end
+        else
+          orig_keypress(event)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- patch TTY::Prompt::List to handle `key:` shortcuts
- require the patch in menu system

## Testing
- `ruby test_fingers.rb` *(fails: undefined method `generate_panel_by_type`)*

------
https://chatgpt.com/codex/tasks/task_e_686abf040708832c8d25b06996eef99b