### PR TITLE
Fix duplicate menu items in project manager

### DIFF
--- a/project_manager.rb
+++ b/project_manager.rb
@@ -178,10 +178,10 @@ class ProjectManager
     choices = projects.map do |project|
       info = get_project_info(project[:filepath])
       description = info ? "#{info[:dimensions]} - #{info[:description]}" : "Unknown"
-      ["#{project[:name]} - #{description}", project[:filepath]]
+      { name: "#{project[:name]} - #{description}", value: project[:filepath] }
     end
 
-    choices << ["❌ Cancel", :cancel]
+    choices << { name: "❌ Cancel", value: :cancel }
 
     choice = @prompt.select("Select a project to load:", choices)
 
@@ -290,8 +290,8 @@ class ProjectManager
     puts @pastel.bold.red("\n🗑️ Delete Project")
     puts @pastel.yellow("⚠️  This action cannot be undone!")
 
-    choices = projects.map { |p| [p[:name], p[:filepath]] }
-    choices << ["❌ Cancel", :cancel]
+    choices = projects.map { |p| { name: p[:name], value: p[:filepath] } }
+    choices << { name: "❌ Cancel", value: :cancel }
 
     choice = @prompt.select("Select a project to delete:", choices)
 
@@ -330,8 +330,8 @@ class ProjectManager
 
     puts @pastel.bold.cyan("\n📄 Duplicate Project")
 
-    choices = projects.map { |p| [p[:name], p[:filepath]] }
-    choices << ["❌ Cancel", :cancel]
+    choices = projects.map { |p| { name: p[:name], value: p[:filepath] } }
+    choices << { name: "❌ Cancel", value: :cancel }
 
     choice = @prompt.select("Select a project to duplicate:", choices)
 
@@ -385,8 +385,8 @@ class ProjectManager
 
     puts @pastel.bold.cyan("\n📤 Export Project")
 
-    choices = projects.map { |p| [p[:name], p[:filepath]] }
-    choices << ["❌ Cancel", :cancel]
+    choices = projects.map { |p| { name: p[:name], value: p[:filepath] } }
+    choices << { name: "❌ Cancel", value: :cancel }
 
     choice = @prompt.select("Select a project to export:", choices)
 
@@ -581,13 +581,13 @@ class ProjectManager
         stock_data = JSON.parse(File.read(filepath), symbolize_names: true)
         props = stock_data[:properties]
         description = "#{stock_data[:material_type]} - #{props[:width]}×#{props[:height]}×#{props[:thickness]}mm"
-        [stock_data[:name], filepath]
+        { name: stock_data[:name], value: filepath }
       rescue
-        [File.basename(filepath, '.json'), filepath]
+        { name: File.basename(filepath, '.json'), value: filepath }
       end
     end
 
-    choices << ["❌ Cancel", :cancel]
+    choices << { name: "❌ Cancel", value: :cancel }
 
     choice = @prompt.select("Select stock material:", choices)
     return if choice == :cancel
@@ -624,13 +624,13 @@ class ProjectManager
         tool_data = JSON.parse(File.read(filepath), symbolize_names: true)
         props = tool_data[:properties]
         description = "#{tool_data[:tool_type]} - #{props[:diameter]}mm #{tool_data[:material]}"
-        [tool_data[:name], filepath]
+        { name: tool_data[:name], value: filepath }
       rescue
-        [File.basename(filepath, '.json'), filepath]
+        { name: File.basename(filepath, '.json'), value: filepath }
       end
     end
 
-    choices << ["❌ Cancel", :cancel]
+    choices << { name: "❌ Cancel", value: :cancel }
 
     choice = @prompt.select("Select cutting tool:", choices)
     return if choice == :cancel

--- a/stock_manager.rb
+++ b/stock_manager.rb
@@ -173,13 +173,13 @@ class StockManager
       info = get_stock_info(stock_file[:filepath])
       if info
         description = "#{info[:material_type]} - #{info[:dimensions]} - #{info[:kerf]}mm kerf"
-        ["#{info[:name]} (#{description})", stock_file[:filepath]]
+        { name: "#{info[:name]} (#{description})", value: stock_file[:filepath] }
       else
-        [stock_file[:name], stock_file[:filepath]]
+        { name: stock_file[:name], value: stock_file[:filepath] }
       end
     end
 
-    choices << ["❌ Cancel", :cancel]
+    choices << { name: "❌ Cancel", value: :cancel }
 
     choice = @prompt.select("Select stock material:", choices, per_page: 15)
 
@@ -372,8 +372,8 @@ class StockManager
 
     puts @pastel.bold.cyan("\n📄 Duplicate Stock Material")
 
-    choices = stock_files.map { |s| [s[:name], s[:filepath]] }
-    choices << ["❌ Cancel", :cancel]
+    choices = stock_files.map { |s| { name: s[:name], value: s[:filepath] } }
+    choices << { name: "❌ Cancel", value: :cancel }
 
     choice = @prompt.select("Select stock to duplicate:", choices, per_page: 15)
     return if choice == :cancel
@@ -416,8 +416,8 @@ class StockManager
     puts @pastel.bold.red("\n🗑️ Delete Stock Material")
     puts @pastel.yellow("⚠️  This action cannot be undone!")
 
-    choices = stock_files.map { |s| [s[:name], s[:filepath]] }
-    choices << ["❌ Cancel", :cancel]
+    choices = stock_files.map { |s| { name: s[:name], value: s[:filepath] } }
+    choices << { name: "❌ Cancel", value: :cancel }
 
     choice = @prompt.select("Select stock to delete:", choices, per_page: 15)
     return if choice == :cancel
@@ -490,8 +490,8 @@ class StockManager
 
     puts @pastel.bold.cyan("\n📤 Export Stock Material")
 
-    choices = stock_files.map { |s| [s[:name], s[:filepath]] }
-    choices << ["❌ Cancel", :cancel]
+    choices = stock_files.map { |s| { name: s[:name], value: s[:filepath] } }
+    choices << { name: "❌ Cancel", value: :cancel }
 
     choice = @prompt.select("Select stock to export:", choices, per_page: 15)
     return if choice == :cancel

--- a/tool_manager.rb
+++ b/tool_manager.rb
@@ -183,13 +183,13 @@ class ToolManager
       info = get_tool_info(tool_file[:filepath])
       if info
         description = "#{info[:tool_type]} - #{info[:diameter]}mm - #{info[:material]}"
-        ["#{info[:name]} (#{description})", tool_file[:filepath]]
+        { name: "#{info[:name]} (#{description})", value: tool_file[:filepath] }
       else
-        [tool_file[:name], tool_file[:filepath]]
+        { name: tool_file[:name], value: tool_file[:filepath] }
       end
     end
 
-    choices << ["❌ Cancel", :cancel]
+    choices << { name: "❌ Cancel", value: :cancel }
 
     choice = @prompt.select("Select cutting tool:", choices, per_page: 15)
 
@@ -429,8 +429,8 @@ class ToolManager
 
     puts @pastel.bold.cyan("\n📄 Duplicate Cutting Tool")
 
-    choices = tool_files.map { |t| [t[:name], t[:filepath]] }
-    choices << ["❌ Cancel", :cancel]
+    choices = tool_files.map { |t| { name: t[:name], value: t[:filepath] } }
+    choices << { name: "❌ Cancel", value: :cancel }
 
     choice = @prompt.select("Select tool to duplicate:", choices, per_page: 15)
     return if choice == :cancel
@@ -473,8 +473,8 @@ class ToolManager
     puts @pastel.bold.red("\n🗑️ Delete Cutting Tool")
     puts @pastel.yellow("⚠️  This action cannot be undone!")
 
-    choices = tool_files.map { |t| [t[:name], t[:filepath]] }
-    choices << ["❌ Cancel", :cancel]
+    choices = tool_files.map { |t| { name: t[:name], value: t[:filepath] } }
+    choices << { name: "❌ Cancel", value: :cancel }
 
     choice = @prompt.select("Select tool to delete:", choices, per_page: 15)
     return if choice == :cancel
@@ -547,8 +547,8 @@ class ToolManager
 
     puts @pastel.bold.cyan("\n📤 Export Cutting Tool")
 
-    choices = tool_files.map { |t| [t[:name], t[:filepath]] }
-    choices << ["❌ Cancel", :cancel]
+    choices = tool_files.map { |t| { name: t[:name], value: t[:filepath] } }
+    choices << { name: "❌ Cancel", value: :cancel }
 
     choice = @prompt.select("Select tool to export:", choices, per_page: 15)
     return if choice == :cancel


### PR DESCRIPTION
## Summary
- fix `load_project` to build TTY prompt options with `name`/`value`
- update stock/tool loading menus to use named choices

## Testing
- `ruby -c project_manager.rb`
- `ruby -c stock_manager.rb`
- `ruby -c tool_manager.rb`


------
https://chatgpt.com/codex/tasks/task_e_686ac6a38d30832cb38800c7bfae7375