### PR TITLE
Update viewer to open SVG preview in browser

### DIFF
--- a/box_maker.rb
+++ b/box_maker.rb
@@ -311,15 +311,35 @@ class BoxMaker
   end
 
   def open_with_viewer(file)
+    preview = File.join(File.dirname(file), "preview_#{File.basename(file, '.svg')}.html")
+    html = <<~HTML
+      <!DOCTYPE html>
+      <html>
+      <head>
+        <meta charset="utf-8" />
+        <title>SVG Preview</title>
+      </head>
+      <body style="margin:0">
+        <object type="image/svg+xml" data="#{File.basename(file)}" width="100%" height="100%"></object>
+      </body>
+      </html>
+    HTML
+    File.write(preview, html)
+
     case RbConfig::CONFIG['host_os']
-      when /darwin/
-        system("open", file)
-      when /linux/
-        system("xdg-open", file)
-      when /mswin|mingw|cygwin/
-        system("start", file)
+    when /darwin/
+      system('open', preview)
+    when /linux/
+      browser = ENV['BROWSER']
+      if browser && !browser.empty?
+        system(browser, preview)
       else
-        puts "Unable to open viewer on this platform"
+        system('xdg-open', preview)
+      end
+    when /mswin|mingw|cygwin/
+      system('start', preview)
+    else
+      puts 'Unable to open browser on this platform'
     end
   end
 


### PR DESCRIPTION
## Summary
- change `open_with_viewer` to generate an HTML wrapper for the SVG
- open the preview HTML file with the default web browser

## Testing
- `bundle install`
- `bundle exec ruby test_fingers.rb`

------
https://chatgpt.com/codex/tasks/task_e_686acc2b66a8832c88d668da3ba85871