### PR TITLE
Use Launchy for preview

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,5 @@ end
 
 # Ruby version requirement
 ruby ">= 2.7.0"
+
+gem "launchy", "~> 3.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,15 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    childprocess (5.1.0)
+      logger (~> 1.5)
+    launchy (3.1.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+      logger (~> 1.6)
+    logger (1.7.0)
     mini_portile2 (2.8.9)
     minitest (5.25.5)
     nokogiri (1.18.8)
@@ -10,6 +19,7 @@ GEM
       racc (~> 1.4)
     pastel (0.8.0)
       tty-color (~> 0.5)
+    public_suffix (6.0.2)
     racc (1.8.1)
     rake (13.3.0)
     svgcode (0.6.2)
@@ -34,6 +44,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  launchy (~> 3.1)
   minitest (~> 5.0)
   pastel (~> 0.8)
   rake (~> 13.0)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # box_maker
 # griffith_box_maker
+
+## Dependencies
+
+Run `bundle install` to install required gems. The application relies on
+`victor`, `tty-prompt`, `pastel`, `svgcode`, and now `launchy` for opening
+generated previews.

--- a/box_maker.rb
+++ b/box_maker.rb
@@ -326,27 +326,8 @@ class BoxMaker
     HTML
     File.write(preview, html)
 
-    case RbConfig::CONFIG['host_os']
-    when /darwin/
-      system('open', '-n', preview)
-    when /linux/
-      browser = ENV['BROWSER']
-      if browser && !browser.empty?
-        cmd = if browser =~ /(firefox|chrome|chromium|brave|edge)/i
-                 [browser, '--new-window', preview]
-               else
-                 [browser, preview]
-               end
-        system(*cmd)
-      else
-        system('xdg-open', preview)
-      end
-    when /mswin|mingw|cygwin/
-      system('start', '', preview)
-
-    else
-      puts 'Unable to open browser on this platform'
-    end
+    require 'launchy'
+    Launchy.open(preview)
   end
 
   def convert_svg_to_gcode(svg_file)


### PR DESCRIPTION
## Summary
- add `launchy` gem for previewing HTML
- simplify viewer logic using `Launchy.open`
- document the new gem dependency

## Testing
- `bundle exec ruby test_fingers.rb`
- `bundle install`

------
https://chatgpt.com/codex/tasks/task_e_686adb3e536c832cbf2c265574209b45