### PR TITLE
Add basic minitest suite and rake test task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,8 @@
+require 'rake/testtask'
+
+Rake::TestTask.new do |t|
+  t.libs << 'test'
+  t.test_files = FileList['test/**/*_test.rb']
+end
+
+task default: :test

--- a/test/finger_joint_calculator_test.rb
+++ b/test/finger_joint_calculator_test.rb
@@ -1,0 +1,18 @@
+require_relative '../finger_joint_calculator'
+require_relative 'test_helper'
+
+class FingerJointCalculatorTest < Minitest::Test
+  def test_calc_centered_fingers_prefers_odd_count
+    calc = FingerJointCalculator.new(finger_width: 10)
+    result = calc.send(:calc_centered_fingers, 100)
+    assert_equal 9, result[:count]
+    assert_in_delta 11, result[:width], 0.01
+  end
+
+  def test_calc_centered_fingers_expands_when_width_far
+    calc = FingerJointCalculator.new(finger_width: 20)
+    result = calc.send(:calc_centered_fingers, 55)
+    assert_equal 3, result[:count]
+    assert_in_delta 18, result[:width], 0.01
+  end
+end

--- a/test/layout_optimizer_test.rb
+++ b/test/layout_optimizer_test.rb
@@ -1,0 +1,32 @@
+require_relative '../layout_optimizer'
+require_relative 'test_helper'
+
+class LayoutOptimizerTest < Minitest::Test
+  def test_single_sheet_layout
+    opt = LayoutOptimizer.new(stock_width: 100, stock_height: 100, part_spacing: 5)
+    opt.add_panel('a', 40, 50)
+    opt.add_panel('b', 30, 30)
+    layout = opt.calculate_layout
+
+    assert_equal 1, layout[:total_sheets]
+    sheet = layout[:sheets].first
+    assert_equal 2, sheet[:panels].size
+    sheet[:panels].each do |p|
+      assert p[:placed]
+      assert_operator p[:x] + p[:width], :<=, sheet[:width]
+      assert_operator p[:y] + p[:height], :<=, sheet[:height]
+    end
+  end
+
+  def test_multiple_sheet_layout
+    opt = LayoutOptimizer.new(stock_width: 100, stock_height: 100, part_spacing: 5)
+    3.times { |i| opt.add_panel("p#{i}", 80, 80) }
+    layout = opt.calculate_layout
+
+    assert_equal 3, layout[:total_sheets]
+    layout[:sheets].each do |sheet|
+      assert_equal 1, sheet[:panels].size
+      assert sheet[:panels].first[:placed]
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,2 @@
+require 'bundler/setup'
+require 'minitest/autorun'


### PR DESCRIPTION
## Summary
- set up `test/` directory with minitest helper
- add unit tests for `FingerJointCalculator` and `LayoutOptimizer`
- include `Rakefile` so `rake test` runs the suite

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_686adb37f938832cae7ae6ff0917d364