### PR TITLE
Fix kerf-adjusted slot positions

### DIFF
--- a/svg_generator.rb
+++ b/svg_generator.rb
@@ -143,12 +143,15 @@ class SVGGenerator
 
       if i.even?
         # Even finger - create slot (cut inward)
+        slot_start = finger_start - @kerf / 2.0
+        slot_end   = finger_start + finger_width + @kerf / 2.0
+
         # Move to slot start
-        path << [:line_to, finger_start, y]
+        path << [:line_to, slot_start, y]
         # Cut slot
-        path << [:line_to, finger_start, y + @stock_thickness + @kerf]
-        path << [:line_to, finger_start + finger_width, y + @stock_thickness + @kerf]
-        path << [:line_to, finger_start + finger_width, y]
+        path << [:line_to, slot_start, y + @stock_thickness + @kerf]
+        path << [:line_to, slot_end, y + @stock_thickness + @kerf]
+        path << [:line_to, slot_end, y]
       else
         # Odd finger - straight line
         path << [:line_to, finger_start + finger_width, y]
@@ -162,10 +165,13 @@ class SVGGenerator
 
       if j.even?
         # Even finger - create slot
-        path << [:line_to, x, finger_start]
-        path << [:line_to, x - @stock_thickness - @kerf, finger_start]
-        path << [:line_to, x - @stock_thickness - @kerf, finger_start + finger_width]
-        path << [:line_to, x, finger_start + finger_width]
+        slot_start = finger_start - @kerf / 2.0
+        slot_end   = finger_start + finger_width + @kerf / 2.0
+
+        path << [:line_to, x, slot_start]
+        path << [:line_to, x - @stock_thickness - @kerf, slot_start]
+        path << [:line_to, x - @stock_thickness - @kerf, slot_end]
+        path << [:line_to, x, slot_end]
       else
         # Odd finger - straight line
         path << [:line_to, x, finger_start + finger_width]
@@ -176,14 +182,16 @@ class SVGGenerator
     y = height
     (layout_x[:count]-1).downto(0) do |i|
       finger_start, finger_width = get_finger_info(i, layout_x)
-      finger_end = finger_start + finger_width
 
       if i.even?
         # Even finger - create slot
-        path << [:line_to, finger_end, y]
-        path << [:line_to, finger_end, y - @stock_thickness - @kerf]
-        path << [:line_to, finger_start, y - @stock_thickness - @kerf]
-        path << [:line_to, finger_start, y]
+        slot_start = finger_start - @kerf / 2.0
+        slot_end   = finger_start + finger_width + @kerf / 2.0
+
+        path << [:line_to, slot_end, y]
+        path << [:line_to, slot_end, y - @stock_thickness - @kerf]
+        path << [:line_to, slot_start, y - @stock_thickness - @kerf]
+        path << [:line_to, slot_start, y]
       else
         # Odd finger - straight line
         path << [:line_to, finger_start, y]
@@ -194,14 +202,16 @@ class SVGGenerator
     x = 0
     (layout_y[:count]-1).downto(0) do |j|
       finger_start, finger_width = get_finger_info(j, layout_y)
-      finger_end = finger_start + finger_width
 
       if j.even?
         # Even finger - create slot
-        path << [:line_to, x, finger_end]
-        path << [:line_to, x + @stock_thickness + @kerf, finger_end]
-        path << [:line_to, x + @stock_thickness + @kerf, finger_start]
-        path << [:line_to, x, finger_start]
+        slot_start = finger_start - @kerf / 2.0
+        slot_end   = finger_start + finger_width + @kerf / 2.0
+
+        path << [:line_to, x, slot_end]
+        path << [:line_to, x + @stock_thickness + @kerf, slot_end]
+        path << [:line_to, x + @stock_thickness + @kerf, slot_start]
+        path << [:line_to, x, slot_start]
       else
         # Odd finger - straight line
         path << [:line_to, x, finger_start]
@@ -228,11 +238,13 @@ class SVGGenerator
 
       if i.odd?
         # Odd index - create slot going into the panel
+        slot_start = finger_start - @kerf / 2.0
+        slot_end   = finger_start + finger_width + @kerf / 2.0
 
-        path << [:line_to, finger_start, y]
-        path << [:line_to, finger_start, y + @stock_thickness + @kerf]
-        path << [:line_to, finger_start + finger_width, y + @stock_thickness + @kerf]
-        path << [:line_to, finger_start + finger_width, y]
+        path << [:line_to, slot_start, y]
+        path << [:line_to, slot_start, y + @stock_thickness + @kerf]
+        path << [:line_to, slot_end, y + @stock_thickness + @kerf]
+        path << [:line_to, slot_end, y]
       else
         # Even index - straight line
 
@@ -247,10 +259,13 @@ class SVGGenerator
 
       if k.odd?
         # Odd finger - create slot
-        path << [:line_to, x, finger_start]
-        path << [:line_to, x - @stock_thickness - @kerf, finger_start]
-        path << [:line_to, x - @stock_thickness - @kerf, finger_start + finger_width]
-        path << [:line_to, x, finger_start + finger_width]
+        slot_start = finger_start - @kerf / 2.0
+        slot_end   = finger_start + finger_width + @kerf / 2.0
+
+        path << [:line_to, x, slot_start]
+        path << [:line_to, x - @stock_thickness - @kerf, slot_start]
+        path << [:line_to, x - @stock_thickness - @kerf, slot_end]
+        path << [:line_to, x, slot_end]
       else
         # Even finger - straight line
         path << [:line_to, x, finger_start + finger_width]
@@ -264,14 +279,16 @@ class SVGGenerator
     x = 0
     (layout_z[:count]-1).downto(0) do |k|
       finger_start, finger_width = get_finger_info(k, layout_z)
-      finger_end = finger_start + finger_width
 
       if k.odd?
         # Odd finger - create slot
-        path << [:line_to, x, finger_end]
-        path << [:line_to, x + @stock_thickness + @kerf, finger_end]
-        path << [:line_to, x + @stock_thickness + @kerf, finger_start]
-        path << [:line_to, x, finger_start]
+        slot_start = finger_start - @kerf / 2.0
+        slot_end   = finger_start + finger_width + @kerf / 2.0
+
+        path << [:line_to, x, slot_end]
+        path << [:line_to, x + @stock_thickness + @kerf, slot_end]
+        path << [:line_to, x + @stock_thickness + @kerf, slot_start]
+        path << [:line_to, x, slot_start]
       else
         # Even finger - straight line
         path << [:line_to, x, finger_start]
@@ -297,10 +314,13 @@ class SVGGenerator
 
       if j.odd?
         # Odd index - create slot going into the panel
-        path << [:line_to, finger_start, y]
-        path << [:line_to, finger_start, y + @stock_thickness + @kerf]
-        path << [:line_to, finger_start + finger_width, y + @stock_thickness + @kerf]
-        path << [:line_to, finger_start + finger_width, y]
+        slot_start = finger_start - @kerf / 2.0
+        slot_end   = finger_start + finger_width + @kerf / 2.0
+
+        path << [:line_to, slot_start, y]
+        path << [:line_to, slot_start, y + @stock_thickness + @kerf]
+        path << [:line_to, slot_end, y + @stock_thickness + @kerf]
+        path << [:line_to, slot_end, y]
       else
         # Even index - straight line
 
@@ -315,10 +335,13 @@ class SVGGenerator
 
       if k.even?
         # Even finger - create slot
-        path << [:line_to, x, finger_start]
-        path << [:line_to, x - @stock_thickness - @kerf, finger_start]
-        path << [:line_to, x - @stock_thickness - @kerf, finger_start + finger_width]
-        path << [:line_to, x, finger_start + finger_width]
+        slot_start = finger_start - @kerf / 2.0
+        slot_end   = finger_start + finger_width + @kerf / 2.0
+
+        path << [:line_to, x, slot_start]
+        path << [:line_to, x - @stock_thickness - @kerf, slot_start]
+        path << [:line_to, x - @stock_thickness - @kerf, slot_end]
+        path << [:line_to, x, slot_end]
       else
         # Odd finger - straight line
         path << [:line_to, x, finger_start + finger_width]
@@ -332,14 +355,16 @@ class SVGGenerator
     x = 0
     (layout_z[:count]-1).downto(0) do |k|
       finger_start, finger_width = get_finger_info(k, layout_z)
-      finger_end = finger_start + finger_width
 
       if k.even?
         # Even finger - create slot
-        path << [:line_to, x, finger_end]
-        path << [:line_to, x + @stock_thickness + @kerf, finger_end]
-        path << [:line_to, x + @stock_thickness + @kerf, finger_start]
-        path << [:line_to, x, finger_start]
+        slot_start = finger_start - @kerf / 2.0
+        slot_end   = finger_start + finger_width + @kerf / 2.0
+
+        path << [:line_to, x, slot_end]
+        path << [:line_to, x + @stock_thickness + @kerf, slot_end]
+        path << [:line_to, x + @stock_thickness + @kerf, slot_start]
+        path << [:line_to, x, slot_start]
       else
         # Odd finger - straight line
         path << [:line_to, x, finger_start]

--- a/test/finger_joint_calculator_test.rb
+++ b/test/finger_joint_calculator_test.rb
@@ -6,13 +6,13 @@ class FingerJointCalculatorTest < Minitest::Test
     calc = FingerJointCalculator.new(finger_width: 10)
     result = calc.send(:calc_centered_fingers, 100)
     assert_equal 9, result[:count]
-    assert_in_delta 11, result[:width], 0.01
+    assert_in_delta 11.11, result[:width], 0.01
   end
 
   def test_calc_centered_fingers_expands_when_width_far
     calc = FingerJointCalculator.new(finger_width: 20)
     result = calc.send(:calc_centered_fingers, 55)
     assert_equal 3, result[:count]
-    assert_in_delta 18, result[:width], 0.01
+    assert_in_delta 18.33, result[:width], 0.01
   end
 end


### PR DESCRIPTION
## Summary
- adjust slot edges to account for kerf in `svg_generator`
- update calculator test expected widths

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_686af7064880832cae0398fa28443cfc