### PR TITLE
Fix finger joint geometry

### DIFF
--- a/test/finger_joint_calculator_test.rb
+++ b/test/finger_joint_calculator_test.rb
@@ -6,13 +6,15 @@ class FingerJointCalculatorTest < Minitest::Test
     calc = FingerJointCalculator.new(finger_width: 10)
     result = calc.send(:calc_centered_fingers, 100)
     assert_equal 9, result[:count]
-    assert_in_delta 11, result[:width], 0.01
+    # 100mm span divided by 9 fingers should give ~11.11mm per finger
+    assert_in_delta 11.11, result[:width], 0.01
   end
 
   def test_calc_centered_fingers_expands_when_width_far
     calc = FingerJointCalculator.new(finger_width: 20)
     result = calc.send(:calc_centered_fingers, 55)
     assert_equal 3, result[:count]
-    assert_in_delta 18, result[:width], 0.01
+    # 55mm span divided by 3 fingers should give ~18.33mm per finger
+    assert_in_delta 18.33, result[:width], 0.01
   end
 end


### PR DESCRIPTION
## Summary
- generate outward tabs on the bottom panel and side panels
- adjust slot/tab parity so sides mate correctly
- update finger joint tests with accurate finger widths

## Testing
- `bundle exec rake`
- `ruby test_fingers.rb` *(fails: SVG slot count mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_686af3f344d8832c8549a48a8c041d38