### PR TITLE
Handle STL dependency gracefully and tidy vector paths

### DIFF
--- a/box_maker.rb
+++ b/box_maker.rb
@@ -9,7 +9,6 @@ require_relative 'finger_joint_calculator'
 require_relative 'svg_generator'
 require_relative 'layout_optimizer'
 require_relative 'project_manager'
-require_relative 'stl_generator'
 
 # Try to load menu system
 begin
@@ -160,8 +159,13 @@ class BoxMaker
     stl_file = nil
     if @options[:generate_stl]
       puts "\n📦 Generating STL assembly..."
-      stl_gen = STLGenerator.new(@options)
-      stl_file = stl_gen.generate(File.join(@options[:output_dir], 'box_assembly.stl'))
+      begin
+        require_relative 'stl_generator'
+        stl_gen = STLGenerator.new(@options)
+        stl_file = stl_gen.generate(File.join(@options[:output_dir], 'box_assembly.stl'))
+      rescue LoadError => e
+        puts "⚠️  STL generation skipped: #{e.message}"
+      end
     end
 
     puts "\n✅ Generated files:"

--- a/svg_generator.rb
+++ b/svg_generator.rb
@@ -140,16 +140,17 @@ class SVGGenerator
     # Even indices create outward fingers, odd indices remain flush
     (0...layout_x[:count]).each do |i|
       finger_start, finger_width = get_finger_info(i, layout_x)
+      finger_end = finger_start + finger_width
 
       if i.even?
         # Even finger - create outward tab
         path << [:line_to, finger_start, y]
         path << [:line_to, finger_start, y - @stock_thickness - @kerf]
-        path << [:line_to, finger_start + finger_width, y - @stock_thickness - @kerf]
-        path << [:line_to, finger_start + finger_width, y]
+        path << [:line_to, finger_end, y - @stock_thickness - @kerf]
+        path << [:line_to, finger_end, y]
       else
         # Odd finger - straight line
-        path << [:line_to, finger_start + finger_width, y]
+        path << [:line_to, finger_end, y]
       end
     end
 
@@ -157,16 +158,17 @@ class SVGGenerator
     x = width
     (0...layout_y[:count]).each do |j|
       finger_start, finger_width = get_finger_info(j, layout_y)
+      finger_end = finger_start + finger_width
 
       if j.even?
         # Even finger - create outward tab
         path << [:line_to, x, finger_start]
         path << [:line_to, x + @stock_thickness + @kerf, finger_start]
-        path << [:line_to, x + @stock_thickness + @kerf, finger_start + finger_width]
-        path << [:line_to, x, finger_start + finger_width]
+        path << [:line_to, x + @stock_thickness + @kerf, finger_end]
+        path << [:line_to, x, finger_end]
       else
         # Odd finger - straight line
-        path << [:line_to, x, finger_start + finger_width]
+        path << [:line_to, x, finger_end]
       end
     end
 
@@ -174,6 +176,7 @@ class SVGGenerator
     y = height
     (layout_x[:count]-1).downto(0) do |i|
       finger_start, finger_width = get_finger_info(i, layout_x)
+      finger_end = finger_start + finger_width
 
       if i.even?
         # Even finger - create outward tab
@@ -191,6 +194,7 @@ class SVGGenerator
     x = 0
     (layout_y[:count]-1).downto(0) do |j|
       finger_start, finger_width = get_finger_info(j, layout_y)
+      finger_end = finger_start + finger_width
 
       if j.even?
         # Even finger - create outward tab
@@ -221,6 +225,8 @@ class SVGGenerator
     # Bottom edge - even indices cut slots to receive bottom panel fingers
     (0...layout_x[:count]).each do |i|
       finger_start, finger_width = get_finger_info(i, layout_x)
+      slot_start = finger_start
+      slot_end   = finger_start + finger_width
 
       if i.even?
         # Even index - create slot going into the panel
@@ -230,8 +236,7 @@ class SVGGenerator
         path << [:line_to, slot_end, y]
       else
         # Odd index - straight line
-
-        path << [:line_to, finger_start + finger_width, y]
+        path << [:line_to, slot_end, y]
       end
     end
 
@@ -239,16 +244,17 @@ class SVGGenerator
     x = width
     (0...layout_z[:count]).each do |k|
       finger_start, finger_width = get_finger_info(k, layout_z)
+      finger_end = finger_start + finger_width
 
       if k.odd?
         # Odd finger - create outward tab
         path << [:line_to, x, finger_start]
         path << [:line_to, x + @stock_thickness + @kerf, finger_start]
-        path << [:line_to, x + @stock_thickness + @kerf, finger_start + finger_width]
-        path << [:line_to, x, finger_start + finger_width]
+        path << [:line_to, x + @stock_thickness + @kerf, finger_end]
+        path << [:line_to, x, finger_end]
       else
         # Even finger - straight line
-        path << [:line_to, x, finger_start + finger_width]
+        path << [:line_to, x, finger_end]
       end
     end
 
@@ -259,6 +265,7 @@ class SVGGenerator
     x = 0
     (layout_z[:count]-1).downto(0) do |k|
       finger_start, finger_width = get_finger_info(k, layout_z)
+      finger_end = finger_start + finger_width
 
       if k.odd?
         # Odd finger - create outward tab
@@ -288,17 +295,17 @@ class SVGGenerator
     # Bottom edge - even indices cut slots to receive bottom panel fingers
     (0...layout_y[:count]).each do |j|
       finger_start, finger_width = get_finger_info(j, layout_y)
+      finger_end = finger_start + finger_width
 
       if j.even?
         # Even index - create slot going into the panel
         path << [:line_to, finger_start, y]
         path << [:line_to, finger_start, y + @stock_thickness + @kerf]
-        path << [:line_to, finger_start + finger_width, y + @stock_thickness + @kerf]
-        path << [:line_to, finger_start + finger_width, y]
+        path << [:line_to, finger_end, y + @stock_thickness + @kerf]
+        path << [:line_to, finger_end, y]
       else
-        # Even index - straight line
-
-        path << [:line_to, finger_start + finger_width, y]
+        # Odd index - straight line
+        path << [:line_to, finger_end, y]
       end
     end
 
@@ -306,16 +313,17 @@ class SVGGenerator
     x = width
     (0...layout_z[:count]).each do |k|
       finger_start, finger_width = get_finger_info(k, layout_z)
+      finger_end = finger_start + finger_width
 
       if k.odd?
         # Odd finger - create slot
         path << [:line_to, x, finger_start]
         path << [:line_to, x - @stock_thickness - @kerf, finger_start]
-        path << [:line_to, x - @stock_thickness - @kerf, finger_start + finger_width]
-        path << [:line_to, x, finger_start + finger_width]
+        path << [:line_to, x - @stock_thickness - @kerf, finger_end]
+        path << [:line_to, x, finger_end]
       else
         # Odd finger - straight line
-        path << [:line_to, x, finger_start + finger_width]
+        path << [:line_to, x, finger_end]
       end
     end
 
@@ -326,6 +334,7 @@ class SVGGenerator
     x = 0
     (layout_z[:count]-1).downto(0) do |k|
       finger_start, finger_width = get_finger_info(k, layout_z)
+      finger_end = finger_start + finger_width
 
       if k.odd?
         # Odd finger - create slot


### PR DESCRIPTION
## Summary
- avoid requiring STL generator unless needed
- handle missing STL gem gracefully during generation
- remove duplicate finger calculations and fix comment in SVG generator

## Testing
- `bundle exec rake test`
- `ruby launch.rb --help`

------
https://chatgpt.com/codex/tasks/task_e_686b16406d48832c88adfa6f533ce195