### PR TITLE
Add small box defaults and example project

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "pastel", "~> 0.8"
 gem "svgcode", "~> 0.6"
 gem "stl", "~> 0.2"
 gem "geometry", "~> 6.6"
+gem "matrix"
 
 group :development do
   gem "rake", "~> 13.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
       childprocess (~> 5.0)
       logger (~> 1.6)
     logger (1.7.0)
+    matrix (0.4.3)
     mini_portile2 (2.8.9)
     minitest (5.25.5)
     nokogiri (1.18.8)
@@ -49,6 +50,7 @@ PLATFORMS
 DEPENDENCIES
   geometry (~> 6.6)
   launchy (~> 3.1)
+  matrix
   minitest (~> 5.0)
   pastel (~> 0.8)
   rake (~> 13.0)

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ bundle install
 Generate a simple box directly from the command line:
 
 ```bash
-ruby box_maker.rb --length 200 --width 150 --height 80 \
-  --finger-width 25 --output ./output --no-open
+ruby box_maker.rb --length 100 --width 80 --height 40 
+  --finger-width 15 --output ./output --no-open
 ```
 
 Run with no arguments (or `--interactive`) to launch the menu driven interface:
@@ -37,7 +37,7 @@ ruby box_maker.rb --help
 Use `--stl` to also generate an assembled box as an STL file for 3‑D preview:
 
 ```bash
-ruby box_maker.rb --length 200 --width 150 --height 80 --stl
+ruby box_maker.rb --length 100 --width 80 --height 40 --stl
 ```
 
 Settings may also be saved and loaded as projects for later use.

--- a/box_maker.rb
+++ b/box_maker.rb
@@ -22,18 +22,18 @@ class BoxMaker
 
   # Default parameters from OpenSCAD file
     DEFAULT_OPTIONS = {
-    box_length: 278,
-    box_width: 498,
-    box_height: 73,
-    stock_thickness: 5.2,
-    stock_width: 1220,    # Stock sheet width in mm
-    stock_height: 1220,    # Stock sheet height in mm
-    finger_width: 40,
+    box_length: 100,
+    box_width: 80,
+    box_height: 40,
+    stock_thickness: 6,
+    stock_width: 300,    # Stock sheet width in mm
+    stock_height: 300,    # Stock sheet height in mm
+    finger_width: 15,
     bit_diameter: 3.175,
-    kerf: 0.3,
-    lid_height: 40,
-    lid_tolerance: 1,
-    part_spacing: 20,
+    kerf: 0.2,
+    lid_height: 20,
+    lid_tolerance: 0.5,
+    part_spacing: 10,
     dogbone_style: 3,
     enable_lid: false,
     enable_dividers: false,

--- a/projects/simple_box.json
+++ b/projects/simple_box.json
@@ -1,0 +1,29 @@
+{
+  "name": "simple_box",
+  "created_at": "2025-07-08T00:00:00Z",
+  "updated_at": "2025-07-08T00:00:00Z",
+  "version": "1.0",
+  "description": "100×80×40mm test box",
+  "configuration": {
+    "box_length": 100,
+    "box_width": 80,
+    "box_height": 40,
+    "stock_thickness": 6,
+    "stock_width": 300,
+    "stock_height": 300,
+    "finger_width": 15,
+    "bit_diameter": 3.175,
+    "kerf": 0.2,
+    "lid_height": 20,
+    "lid_tolerance": 0.5,
+    "part_spacing": 10,
+    "dogbone_style": 3,
+    "enable_lid": false,
+    "enable_dividers": false,
+    "enable_x_divider": true,
+    "enable_y_divider": true,
+    "output_dir": "./output",
+    "open_viewer": true,
+    "interactive": true
+  }
+}

--- a/test/finger_alignment_test.rb
+++ b/test/finger_alignment_test.rb
@@ -1,0 +1,11 @@
+require_relative '../finger_joint_calculator'
+require_relative 'test_helper'
+
+class FingerAlignmentTest < Minitest::Test
+  def test_total_width_matches_span
+    calc = FingerJointCalculator.new(finger_width: 15)
+    result = calc.send(:calc_centered_fingers, 100)
+    total = result[:count] * result[:width]
+    assert_in_delta 100, total, 0.001, 'Total finger widths should equal span'
+  end
+end


### PR DESCRIPTION
## Summary
- default to a tiny 100×80×40 mm box for easier verification
- update README quick start example accordingly
- include a simple `simple_box.json` project
- test that finger widths sum to the span

## Testing
- `bundle install`
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_686d7a3f6d44832c809058dc49c2c36b